### PR TITLE
docs: add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight macOS tool for interactively previewing **blendshapes (morph targe
 
 Perfect for 3D artists and developers who want to quickly inspect facial expressions, body morphs, or any blendshape-driven animations without opening heavy 3D software.
 
-<!-- ![Demo](screenshots/demo.gif) -->
+https://github.com/user-attachments/assets/d71a8d18-3da1-4cdc-9fda-9f2218796be1
 
 ## Features
 


### PR DESCRIPTION
## Summary
Add demo video to README by replacing the commented-out placeholder with a direct GitHub asset URL.

## Changes
- Replace commented `![Demo](screenshots/demo.gif)` with a GitHub-hosted video URL
- Makes the demo immediately visible to users viewing the repository

## Motivation
The README previously had a commented-out demo placeholder. Adding a working video link improves the repository's presentation and helps users quickly understand what BlendShapeLab does.

## Testing
- Verified the video URL is accessible
- Confirmed markdown renders correctly on GitHub

## Risks
- None significant; this is a documentation-only change