### PR TITLE
chore: clean up VSCode settings and fix project paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,5 @@
   "swift.swiftEnvironmentVariables": {
     "DEVELOPER_DIR": "/Applications/Xcode.app/Contents/Developer"
   },
-  "sweetpad.build.xcodeWorkspacePath": "frontend/Humanoid-VisionOS.xcodeproj/project.xcworkspace"
+  "sweetpad.build.xcodeWorkspacePath": "BlendShapeLab.xcodeproj/project.xcworkspace"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "emeraldwalk.runonsave": {
-    "commands": [
-      {
-        "match": ".*\\.swift$",
-        "cmd": "workbench.action.tasks.runTask Format Current File"
-      },
-      {
-        "match": ".*\\.swift$",
-        "cmd": "workbench.action.tasks.runTask Lint Current File"
-      }
-    ]
-  },
   "triggerTaskOnSave.tasks": {
     "Format Current File": ["**/*.swift"],
     "Lint Current File": ["**/*.swift"]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,7 +34,10 @@
         "-c",
         "if [ \"${fileExtname}\" = \".swift\" ]; then xcrun swift-format --in-place \"${file}\"; fi"
       ],
-      "problemMatcher": []
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "silent"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
Clean up VSCode configuration files and fix incorrect project paths.

## Changes
- Remove redundant `emeraldwalk.runonsave` config (duplicated functionality with `triggerTaskOnSave`)
- Fix `sweetpad.build.xcodeWorkspacePath` to point to correct project
- Add `presentation: { reveal: "silent" }` to Format task to suppress terminal on save

## Motivation
- The `emeraldwalk.runonsave` config was specifying VSCode commands as shell commands, which doesn't work
- SweetPad workspace path was pointing to a different project

## Testing
- Verified VSCode settings file syntax

## Risks
- Low risk: configuration cleanup only